### PR TITLE
Fix avatars on android

### DIFF
--- a/app/components/Avatar/index.js
+++ b/app/components/Avatar/index.js
@@ -7,7 +7,7 @@ import theme from '../../theme';
 type Props = {
   size?: number,
   source: string,
-  style?: Object,
+  style: Object | null | Array<Object | null>,
 };
 
 export default function Avatar({ size = 44, source, style, ...props }: Props) {

--- a/app/scenes/Schedule/components/Talk/index.js
+++ b/app/scenes/Schedule/components/Talk/index.js
@@ -4,7 +4,6 @@ import {
   Animated,
   Easing,
   PixelRatio,
-  Platform,
   StyleSheet,
   Text,
   TouchableHighlight,

--- a/app/scenes/Schedule/components/Talk/index.js
+++ b/app/scenes/Schedule/components/Talk/index.js
@@ -4,6 +4,7 @@ import {
   Animated,
   Easing,
   PixelRatio,
+  Platform,
   StyleSheet,
   Text,
   TouchableHighlight,
@@ -195,19 +196,12 @@ export default class Talk extends Component {
     // avatar variants
     const avatar = Array.isArray(speaker)
       ? speaker.map((s, i) => {
-          const borderWidth = 3;
-          const border = { borderColor: 'white', borderWidth };
           const pull = i + 1 !== speaker.length
-            ? { backgroundColor: 'transparent', marginRight: -20 }
+            ? { backgroundColor: 'transparent', marginRight: -16 }
             : null;
 
           return (
-            <Avatar
-              key={s.name}
-              source={s.avatar}
-              style={[border, pull]}
-              size={44 + borderWidth * 2}
-            />
+            <Avatar key={s.name} source={s.avatar} style={pull} size={50} />
           );
         })
       : <Avatar source={speaker && speaker.avatar} />;


### PR DESCRIPTION
Resolves #29.

Unfortunately the border doesn't work correctly with android. We need to either figure out a way to make it work on android or remove it. I couldn't get the math to work correctly on both platforms and with both sizes of avatar, so for now I'm just removing it.

Happy to revisit if we can get it to work on android.